### PR TITLE
docs: babel-eslint is a dependency of the config

### DIFF
--- a/README.org
+++ b/README.org
@@ -5,7 +5,7 @@
 1. ~yarn add eslint-config-sparkbox~
   - Depending on your editor setup you may need the following dependencies installed globally (~-g~) through `npm`.
     #+BEGIN_SRC shell
-      npm i eslint-config-airbnb eslint-plugin-jsx-a11y eslint-plugin-react eslint-plugin-import eslint-plugin-flowtype --save-dev
+      npm i eslint-config-airbnb eslint-plugin-jsx-a11y eslint-plugin-react eslint-plugin-import eslint-plugin-flowtype babel-eslint --save-dev
     #+END_SRC
 2. Use ~extends~ [[http://eslint.org/docs/developer-guide/shareable-configs#using-a-shareable-config][syntax]] in your ~eslint~ config.
 3. ?


### PR DESCRIPTION
For editors that require dependencies installed globally, this 
includes babel-eslint in those installed