### PR TITLE
chore: update dependenies to work with ESLint 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-sparkbox",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A set of eslint customizations that we use at Sparkbox.",
   "main": "index.js",
   "scripts": {
@@ -18,11 +18,11 @@
   "author": "Sparkbox",
   "license": "ISC",
   "dependencies": {
-    "babel-eslint": "^7.1.1",
-    "eslint-config-airbnb": "^12.0.0",
-    "eslint-plugin-flowtype": "^2.20.0",
-    "eslint-plugin-import": "^2.0.1",
-    "eslint-plugin-jsx-a11y": "^2.2.3",
-    "eslint-plugin-react": "^6.4.1"
+    "babel-eslint": "^7.2.2",
+    "eslint-config-airbnb": "^15.1.0",
+    "eslint-plugin-flowtype": "^2.35.0",
+    "eslint-plugin-import": "^2.7.0",
+    "eslint-plugin-jsx-a11y": "^5.1.1",
+    "eslint-plugin-react": "^7.1.0"
   }
 }


### PR DESCRIPTION
This should allow us to use ESLint 4. Pinging @bryanbraun and/or @dflynn15 to double check this.