### PR TITLE
fix: Remove installedESLint option

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 module.exports = {
     "extends": "airbnb",
-    "installedESLint": true,
     "parser": "babel-eslint",
     "plugins": [
         "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-sparkbox",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A set of eslint customizations that we use at Sparkbox.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
`installedESLint` breaks ESLint `4.x` with this error:

```
Unexpected top-level property "installedESLint".
```

Looks like this setting was erroneously added and then removed last year:
https://github.com/eslint/eslint/issues/7758