### PR TITLE
chore: separate release from push

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,11 @@ This will:
 - Use all commit messages since the latest version tag to determine the correct new version
 - Increment the version in package.json and package-lock.json
 - Create a tagged commit with the new version
+
+```sh
+npm run release:push
+```
+
 - Push your branch (and new tag) to the remote
 
 After your branch is merged, CI will take care of publishing to the npm registry.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha test.js",
-    "tag": "git push --follow-tags origin head",
+    "release:push": "git push --follow-tags origin head",
     "release": "standard-version"
   },
   "keywords": [


### PR DESCRIPTION
This means that two scripts are required to create and push a release, but it makes
it easier to create a specific version.

Example:

1. `npm run release release-as minor`
2. `npm run release:push`